### PR TITLE
Added fix for missing ack on read device id (0xF2)

### DIFF
--- a/PS2MouseHandler.cpp
+++ b/PS2MouseHandler.cpp
@@ -136,7 +136,10 @@ void PS2MouseHandler::set_mode(int data) {
 
 int PS2MouseHandler:: get_device_id(){
   write(0xf2); // Ask mouse for device ID.
-  int id =  read_byte(); // Read first byte - gives overall device id
+  int id = read_byte(); // Read first byte - gives overall device id
+  if (id == 0xFA) {
+    id = read_byte(); // first byte was really the ack byte (as per PS/2 spec), so read it again
+  }
   read_byte(); // try to read second byte if sent - refines device type - not needed
   return id;
 }


### PR DESCRIPTION
This is implemented as per the PS/2 spec. Backwards compatible in case there are mice out there that don't send the ack